### PR TITLE
added switches for fake localisation

### DIFF
--- a/uol_cmp9767m_base/launch/thorvald-sim.launch
+++ b/uol_cmp9767m_base/launch/thorvald-sim.launch
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 
 <launch>
+  <arg name="fake_localisation" default="false" doc="fake the localisation, sets map_server and world_tf to true."/>
+  <arg name="world_tf" default="$(arg fake_localisation)" doc="provide a tf link to the world (default: false)"/>
+  <arg name="map_server" default="$(arg fake_localisation)" doc="provide a tf link between map and world and run a map server (default: false)"/>
   <arg name="gui" default="true" doc="run with visible gazebo"/>
   <arg name="obstacles" default="false" doc="run with human walking around"/>
   <arg name="second_robot" default="false" doc="launch a second Thorvald" />
@@ -26,7 +29,7 @@
     <arg name="x" value="-5.0" />
   </include>
 
-  <group>
+  <group if="$(arg world_tf)">
     <node 
       name="world_tf_thorvald_001"
       pkg="tf"
@@ -38,7 +41,7 @@
       type= "static_transform_publisher"
       args="0 0 0 0 0 0 /world /thorvald_002/odom 100"  if="$(arg second_robot)"/>
   </group>
-  <group>
+  <group if="$(arg map_server)">
     <node 
       name="map_server"
       pkg="map_server"

--- a/uol_cmp9767m_base/tests/testme.test
+++ b/uol_cmp9767m_base/tests/testme.test
@@ -1,7 +1,8 @@
 <launch>
   <include file="$(find uol_cmp9767m_base)/launch/thorvald-sim.launch">
     <env name="DISPLAY" value="" />
-  	<arg name="gui" value="false" />
+    <arg name="gui" value="false" />
+    <arg name="fake_localisation" value="true" />
   </include>
 
   <!-- a very basic Python unittest -->
@@ -30,10 +31,10 @@
 
   <!-- check that odometry is published at around 20Hz -->
   <test test-name="hztest_odom" pkg="rostest" type="hztest" name="hztest_odom">
-	<param name="topic" value="/thorvald_001/odometry/gazebo" />
-	<param name="hz" value="20.0" />
-	<param name="hzerror" value="2" />
-	<param name="test_duration" value="10.0" />
+  <param name="topic" value="/thorvald_001/odometry/gazebo" />
+  <param name="hz" value="20.0" />
+  <param name="hzerror" value="2" />
+  <param name="test_duration" value="10.0" />
   </test>
 
   <!-- a very basic Python unittest -->


### PR DESCRIPTION
as discussed on Slack:


I have now added three additional arguments to the launch file:

```
roslaunch --ros-args uol_cmp9767m_base thorvald-sim.launch 
Optional Arguments:
  fake_localisation (default "false"): fake the localisation, sets map_server and world_tf to true.
  gui (default "true"): run with visible gazebo
  map_server (default "false"): provide a tf link between map and world and run a map server (default: false)
  obstacles (default "false"): run with human walking around
  second_robot (default "false"): launch a second Thorvald
  world_tf (default "false"): provide a tf link to the world (default: false)

```

So, default is there is now map server and there is no link to `world` (as there is in a real robot)
So if people start their own `map_server` and `acml` then that will provide the link between `map` and `base_link`
If `map_server` is set to `true`, i.e., `roslaunch uol_cmp9767m_base thorvald-sim.launch map_server:=true`, then there is an additional link between `world` and the `map`, using our provided map.

if `world_tf` is also set `true`, then we get back to what we had previously, i.e., no localisation is needed at all and a fake localisation is running, as it will provide 100% accurate localisation between the `base_link` and the `world`.

I added `fake_localisation` as a convenient argument. So, put simply:
* `roslaunch uol_cmp9767m_base thorvald-sim.launch fake_localisation:=true` will run the same as we had before, i.e., we have a fake localisation system, and running AMCL will both not be needed and cause problems
* the new default `roslaunch uol_cmp9767m_base thorvald-sim.launch fake_localisation:=false` (`fake_localisation:=false` is optional!) will *not* run the fake localisation, providing the same as a real robot would, and allowing people to use own map-servers and provide localisation themselves