### PR TITLE
fix the unit tests for bacchus_gazebo

### DIFF
--- a/uol_cmp9767m_base/tests/testme.test
+++ b/uol_cmp9767m_base/tests/testme.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find uol_cmp9767m_base)/launch/thorvald-sim.launch">
+  <include file="$(find bacchus_gazebo)/launch/vineyard_demo.launch">
     <env name="DISPLAY" value="" />
     <arg name="gui" value="false" />
     <arg name="fake_localisation" value="true" />
@@ -23,7 +23,10 @@
         - name: /thorvald_001/velodyne_points
           timeout: 10
           negative: False
-        - name: /thorvald_001/scan
+        - name: /thorvald_001/front_scan
+          timeout: 10
+          negative: False
+        - name: /thorvald_001/back_scan
           timeout: 10
           negative: False
     </rosparam>


### PR DESCRIPTION
This is to finally get the test cases running again in CMP9767M. This is needed due to using the new BACCHUS system underpinning the work in this repository.